### PR TITLE
updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Options:
 ## Requirements
 * [AWS CLI](https://aws.amazon.com/cli/)
 * Python
+* AWS CLI must be configured to use JSON
 
 ## Installation
 ```


### PR DESCRIPTION
Added as a requirement that aws cli has to be configured to use JSON otherwise the tool will not work
