### PR TITLE
aws cli defaults on json

### DIFF
--- a/ssh2
+++ b/ssh2
@@ -51,7 +51,7 @@ if options.bust_cache or not os.path.exists(cache_file_list) \
   print "Fetching servers..."
   if os.path.exists(cache_file_num):
     os.remove(cache_file_num)
-  aws_cmd = 'aws ec2 describe-instances'
+  aws_cmd = 'aws ec2 describe-instances --output json'
   if options.profile:
     aws_cmd += ' --profile ' + options.profile
 


### PR DESCRIPTION
aws cli is using json as output so it doesn't freak out when the user has any other output.
