### PR TITLE
adds filters of EC2 instance names

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,22 @@ Options:
                         provide AWS profile
   --ip=IP               connect using IP instead of DNS
   -g GREP, --grep=GREP  filter the server list
+```
 
-$ ssh2 -g Cron
+### Filtering the list by EC2 instance name
+
+```
+$ ssh2 -g webrt
 
 Servers list:
 
-[1]  ec2-XXX-XXX-XXX-XXX.us-west-2.compute.amazonaws.com       Cron
+[1]  ec2-XX-XX-XX-XX.us-west-2.compute.amazonaws.com       webrtc-kurento
 
-Which server would you like to connect to [1]? 
+Which server would you like to connect to [1]? ^C
+
+$ ssh2 -g webrt 1
+
+Connecting to webrtc-kurento ec2-XX-XX-XX-XX.us-west-2.compute.amazonaws.com
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,18 @@ Options:
   -p PROFILE, --profile=PROFILE
                         provide AWS profile
   --ip=IP               connect using IP instead of DNS
+  -g GREP, --grep=GREP  filter the server list
+
+$ ssh2 -g Cron
+
+Servers list:
+
+[1]  ec2-XXX-XXX-XXX-XXX.us-west-2.compute.amazonaws.com       Cron
+
+Which server would you like to connect to [1]? 
 ```
+
+
 
 ## Requirements
 * [AWS CLI](https://aws.amazon.com/cli/)

--- a/ssh2
+++ b/ssh2
@@ -24,6 +24,9 @@ parser.add_option("-r", "--region", action="store",
 parser.add_option("--ip", action="store",
           dest="ip", default=0,
     help="connect using IP instead of DNS")
+parser.add_option("-g", "--grep", action="store",
+          dest="grep", default="",
+    help="filter the server list")
 (options, args) = parser.parse_args()
 
 cache_dir = os.environ.get('XDG_CACHE_HOME',
@@ -87,6 +90,9 @@ if not parsed['Reservations']:
 for instances in parsed['Reservations']:
   for instance in instances['Instances']:
     all_instances.append(instance)
+
+if options.grep:
+  all_instances = [inst for inst in all_instances if options.grep in extract_name(inst)]
 
 if not num:
   print "\nServers list:\n"


### PR DESCRIPTION
Adds filtering ability for those of us with more than a handful of instances to manage.

```
$ ssh2 -g webrt

Servers list:

[1]  ec2-XX-XX-XX-XX.us-west-2.compute.amazonaws.com       webrtc-kurento

Which server would you like to connect to [1]? ^C

$ ssh2 -g webrt 1

Connecting to webrtc-kurento ec2-XX-XX-XX-XX.us-west-2.compute.amazonaws.com
```
